### PR TITLE
adds cross-OS path-handling logic

### DIFF
--- a/contest/utils/paths.py
+++ b/contest/utils/paths.py
@@ -62,12 +62,12 @@ def get_paths(artifact, column=None):
   
   if isinstance(paths, pd.Series):
         paths = paths.apply(convert_path_to_os)
-    else:
-        for column in ["raw", "output", "annotation"]:
-            try:
-                paths[column] = paths[column].apply(convert_path_to_os)
-            except KeyError:
-              pass
+  else:
+    for column in ["raw", "output", "annotation"]:
+      try:
+        paths[column] = paths[column].apply(convert_path_to_os)
+      except KeyError:
+        pass
       
   return paths
 

--- a/contest/utils/paths.py
+++ b/contest/utils/paths.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 
 import pandas as pd
 
@@ -40,6 +41,8 @@ def get_paths(artifact, column=None):
   the information about paths to associated DAVIS files
   for the provided wandb.Artifact, optionally from a specific column.
   
+  Paths are converted to conform with the constraints of the operating system
+  executing this function. See convert_path_to_os.
   The returned pandas object is always sorted by index.
   """
   try:
@@ -48,15 +51,44 @@ def get_paths(artifact, column=None):
     raise Exception("Artifact did not contain a path.json file at top-level.\n"
                     "All dataset and result Artifacts need a paths.json file listing associated files.")
 
-  paths_df = pd.read_json(paths_filename)
-  paths_df.sort_index(inplace=True)
+  paths = pd.read_json(paths_filename)
+  paths.sort_index(inplace=True)
   
   if column is not None:
     try:
-      paths_series = paths_df[column]
+      paths = paths[column]
     except KeyError:
       raise KeyError(f"could not find column {column} in {paths_filename}")
-  else:
-    return paths_df
+  
+  if isinstance(paths, pd.Series):
+        paths = paths.apply(convert_path_to_os)
+    else:
+        for column in ["raw", "output", "annotation"]:
+            try:
+                paths[column] = paths[column].apply(convert_path_to_os)
+            except KeyError:
+              pass
+      
+  return paths
 
-  return paths_series
+
+def convert_path_to_os(path_string):
+    """Attempts to convert path_string from format of original OS
+    to format of OS running this code. Fails on paths
+    that mix forward and backward slashes, which are not
+    transferable between Posix and Windows.
+    """
+    assert_compatibility(path_string)
+    
+    path_string = path_string.replace("\\", "/")
+    try:
+        path = pathlib.PosixPath(path_string)
+    except NotImplementedError:
+        path = pathlib.WindowsPath(path_string)
+
+    return str(path)
+
+
+def assert_compatibility(path_string):
+    error_msg = f"found mixed forward and backward slashes in path: {path_string}"
+    assert not ("\\" in path_string and "/" in path_string), error_msg


### PR DESCRIPTION
At cost of disallowing use of slashes in filenames, allows paths to be ported across OSes